### PR TITLE
Break MSIM dependency on qci-telephony-framework

### DIFF
--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -503,6 +503,10 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
                 loge("Failed to get pref, slotId: "+ mSlotId +" Exception: " + ex);
             }
 
+            if (mUiccProvisionStatus[mSlotId] == INVALID_STATE) {
+                mUiccProvisionStatus[mSlotId] = PROVISIONED;
+            }
+
             boolean isSubValid = isCurrentSubValid();
             setEnabled(isSubValid);
 


### PR DESCRIPTION
If the provisioning state is invalid, the framework is most likely
absent. Consider the card as provisioned to pass all relevant checks.

Change-Id: I975ff156e4328e9d3f6e2626a863bbacb29e3337
